### PR TITLE
Make exact-reals work with new packages and ghc 8.0.1

### DIFF
--- a/exact-real.cabal
+++ b/exact-real.cabal
@@ -29,9 +29,9 @@ library
     Data.CReal.Converge
     Data.CReal.Internal
   build-depends:
-    base        >= 4.8 && < 4.9,
+    base        >= 4.8 && < 4.10,
     integer-gmp           < 1.1.0.0,
-    memoize     >= 0.7 && < 0.8,
+    memoize     >= 0.7 && < 0.9,
     random      >= 1.0 && < 1.2
   hs-source-dirs:
     src

--- a/src/Data/CReal/Converge.hs
+++ b/src/Data/CReal/Converge.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE ConstrainedClassMethods #-}
 
 -- | The Converge type class.
 module Data.CReal.Converge


### PR DESCRIPTION
I tested this change only with the new versions of the packages and ghc, as the haskell tooling makes everything else pretty painful.

Maybe you can test that configuration? Otherwise it would probably sane to narrow the version restriction even further.

Tests pass fine with my environment.