### PR TITLE
Regenerate cabal file with hpack 0.34.4

### DIFF
--- a/exact-real.cabal
+++ b/exact-real.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.31.2.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 9f1a27b06d4316824ca3caaa65a5b6fb0411c526e4c15accd95284e3e7e1512c
+-- hash: a3ed88b1c24f4bd538023fef2038895690266a2d67bf3ee72576d91417e940b4
 
 name:           exact-real
 version:        0.12.2
@@ -18,7 +18,8 @@ maintainer:     Joe Hermaszewski <keep.it.real@monoid.al>
 copyright:      2015 Joe Hermaszewski
 license:        MIT
 license-file:   LICENSE
-tested-with:    GHC>=7.10 && <=8.0.1
+tested-with:
+    GHC>=7.10 && <=8.0.1
 build-type:     Simple
 extra-source-files:
     .gitignore


### PR DESCRIPTION
Minor change in formatting tested-with field, apart from the hash and hpack version comment.